### PR TITLE
✨ Add cleanup using system prune

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,16 @@ services:
           cpus: '0.05'
           memory: 32M
 
+  cluster_cleanup:
+    image: docker
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    command: docker system prune --all --force
+    deploy:
+      mode: global
+      restart_policy:
+        delay: 24h
+
 networks:
   net:
     driver: overlay


### PR DESCRIPTION
### Context
When updating services in the Swarm cluster the old images are left there consuming disk space and this could eventually lead to problems.

This is what `docker system df` shows:

```
TYPE                TOTAL               ACTIVE              SIZE                RECLAIMABLE
Images              26                  11                  4.665GB             3.569GB (76%)
Containers          15                  3                   390.3MB             343.9MB (88%)
Local Volumes       1                   0                   322.2kB             322.2kB (100%)
Build Cache         0                   0                   0B                  0B
```

In this case the instance has only 10Gb of disk space and almost half of it is consumed by unused images/containers.

### Proposal
This PR adds a docker image with a restart policy of 24h which runs `docker system prune --all` to cleanup those images and containers.

After using using `docker system prune --all` in the example avobe:

```
Total reclaimed space: 3.264GB
```

```
TYPE                TOTAL               ACTIVE              SIZE                RECLAIMABLE
Images              3                   3                   1.745GB             0B (0%)
Containers          3                   3                   46.4MB              0B (0%)
Local Volumes       1                   0                   322.2kB             322.2kB (100%)
Build Cache         0                   0                   0B                  0B
```